### PR TITLE
Update overlay, fix Dark Reader issue

### DIFF
--- a/src/scripts/placeDE-overlay.user.js
+++ b/src/scripts/placeDE-overlay.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         r/placeDE Template
 // @namespace    http://tampermonkey.net/
-// @version      5
+// @version      6
 // @description  try to take over the canvas!
 // @author       placeDE Devs
 // @match        https://garlic-bread.reddit.com/embed*

--- a/src/scripts/placeDE-overlay.user.js
+++ b/src/scripts/placeDE-overlay.user.js
@@ -13,7 +13,7 @@
 var overlayImage = null;
 if (window.top !== window.self) {
     window.addEventListener('load', () => {
-        const canvasContainer = document.getElementsByTagName("garlic-bread-embed")[0].shadowRoot.children[0].getElementsByTagName("garlic-bread-canvas")[0].shadowRoot.children[0];
+        const canvasContainer = document.querySelector("garlic-bread-embed").shadowRoot.querySelector("div.layout").querySelector("garlic-bread-canvas").shadowRoot.querySelector("div.container");
         overlayImage = document.createElement("img");
         updateImage();
         overlayImage.style = `position: absolute;left: 0;top: 0;image-rendering: pixelated;width: 1000px;height: 1000px;`;


### PR DESCRIPTION
Durch das Nutzen von Addons, welche den Seiteninhalt ändern, ändert sich teilweise auch die Reihenfolge der Kinder von den Elementen. Somit funktioniert unter Umständen der Selektor nicht korrekt.

Dies sollte das beheben.