### PR TITLE
Fix Overlay funktioniert auf Firefox nicht

### DIFF
--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -9,6 +9,7 @@
 // @updateURL    https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/advanced-overlay.user.js
 // @downloadURL  https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/advanced-overlay.user.js
 // @grant        none
+// @run-at   document-start
 // ==/UserScript==
 
 let width = "2000px";

--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         r/place 2023 Canada Overlay with German tiles
 // @namespace    http://tampermonkey.net/
-// @version      0.10
+// @version      0.11
 // @description  Script that adds a button to toggle an hardcoded image shown in the 2023's r/place canvas
 // @author       max-was-here and placeDE Devs
 // @match        https://garlic-bread.reddit.com/embed*

--- a/src/scripts/placeDE-overlay.user.js
+++ b/src/scripts/placeDE-overlay.user.js
@@ -8,6 +8,7 @@
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=reddit.com
 // @updateURL    https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/placeDE-overlay.user.js
 // @downloadURL  https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/placeDE-overlay.user.js
+// @run-at   document-start
 // ==/UserScript==
 
 var overlayImage = null;

--- a/src/scripts/placeDE-overlay.user.js
+++ b/src/scripts/placeDE-overlay.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         r/placeDE Template
 // @namespace    http://tampermonkey.net/
-// @version      8.4
+// @version      8.5
 // @description  try to take over the canvas!
 // @author       placeDE Devs
 // @match        https://garlic-bread.reddit.com/embed*


### PR DESCRIPTION
Tampermonkey kann meistens bei Firefox keinen Code injecten, wenn das Dokument noch im Laden ist. Die direktive ´´´// @run-at   document-start´´´ sagt Tampermonkey die Injection erst nach dem vollständigen Laden des Dokuments durchzuführen. Aus eigener Testung: hat Problem behoben