### PR TITLE
In der readme Hinweis für Chrome-Nutzer hinzugefügt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,18 @@ Direktlinks:
    
    ![Download-Fenster](img/tapermonkey-marker.png)
 
-3. Anschließend auf einen der folgenden Links klicken, um das jeweilige Overlay zu installieren, Tampermonkey sollte sich automatisch öffnen (wenn du dich nicht entscheiden kannst, findest du die Unterschiede [hier](#wie-funktioniert-das-overlay)):
+3. **WICHTIG: Wenn du Chrome/Opera/Edge/Brave oder einen anderen Chromium-basierten Browser nutzt:**
+
+   Geh auf die Chrome Erweiterungseinstellungen ([about://extensions](about://extensions)) und aktiviere oben rechts den Schalter für den Entwicklermodus.
+   Klicke dann bei Tampermonkey auf "Details" und, wenn die Option da ist, erlaube Tampermonkey, Nutzerscripts zu installieren.
+
+
+
+4. Anschließend auf einen der folgenden Links klicken, um das jeweilige Overlay zu installieren, Tampermonkey sollte sich automatisch öffnen (wenn du dich nicht entscheiden kannst, findest du die Unterschiede [hier](#wie-funktioniert-das-overlay)):
    - [Normales Overlay](https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/placeDE-overlay.user.js)  
    - [Erweitertes Overlay](https://github.com/PlaceDE-Official/place-overlay/raw/main/src/scripts/advanced_overlay.user.js)
 
-4. Nun drückt ihr in Tampermonkey nur noch auf "Updaten" oder "Neu installieren".  
+5. Nun drückt ihr in Tampermonkey nur noch auf "Updaten" oder "Neu installieren".  
 Das Ganze sieht dann in Tampermonkey (abhängig von der gewählten Variante) ungefähr so aus:
    
    ![Addonseite von Tampermonkey](img/script-uebersicht.png)

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Das Ganze sieht dann in Tampermonkey (abhängig von der gewählten Variante) ung
 ------
 
 ## Overlay updaten
-Um das Overlay auf eine neue Version zu aktualisieren (nicht die Daten, sondern das Skript) klickt ihr einfach oben bei 3. auf den entsprechenden Link.
+Um das Overlay auf eine neue Version zu aktualisieren (nicht die Daten, sondern das Skript) klickt ihr einfach oben bei 4. auf den entsprechenden Link.
 
 --------
 


### PR DESCRIPTION
Hab grad zwei Leuten geholfen, das Overlay zu installieren. Bei beiden war in Chrome der Entwicklermodus für Erweiterungen aus. Da könnte man evtl noch Bilder hinzufügen, ich hab aber leider Chrome auf englisch