### PR TITLE
fix(advanced): restore outline and shadows of custom buttons and avoid overlap with normal ui on small screens

### DIFF
--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -34,8 +34,6 @@ const AO_STYLE = `
     width: 44px;
     background-color: #fff;
     color: #000;
-    border: var(--pixel-border);
-    box-shadow: var(--pixel-box-shadow);
     font-family: var(--garlic-bread-font-pixel);
     cursor: pointer;
   }
@@ -52,8 +50,6 @@ const AO_STYLE = `
     height: 132px;
     background-color: #fff;
     color: #000;
-    border: var(--pixel-border);
-    box-shadow: var(--pixel-box-shadow);
     font-family: var(--garlic-bread-font-pixel);
     white-space: nowrap;
     box-sizing: border-box;
@@ -259,7 +255,7 @@ addEventListener('load', () => {
 
 	const addButton = (content, title, onClick) => {
 		const button = document.createElement('button');
-		button.classList.add('ao-button');
+    button.classList.add('ao-button', 'outlined', 'dropshadow');
 		button.onclick = onClick;
 		button.innerHTML = content;
 		button.title = title;
@@ -269,8 +265,12 @@ addEventListener('load', () => {
 	};
 
 	const addSlider = (text, min, max, val, onChange) => {
-		const opacityWrapper = document.createElement('div');
-		opacityWrapper.classList.add('ao-opacity-wrapper');
+    const opacityWrapper = document.createElement('div');
+    opacityWrapper.classList.add(
+      'ao-opacity-wrapper',
+      'outlined',
+      'dropshadow',
+    );
 		opacityWrapper.title = text;
 
 		const opacitySlider = document.createElement('input');

--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -261,7 +261,7 @@ addEventListener('load', () => {
 
 	const addButton = (content, title, onClick) => {
 		const button = document.createElement('button');
-    button.classList.add('ao-button', 'outlined', 'dropshadow');
+		button.classList.add('ao-button', 'outlined', 'dropshadow');
 		button.onclick = onClick;
 		button.innerHTML = content;
 		button.title = title;
@@ -271,12 +271,8 @@ addEventListener('load', () => {
 	};
 
 	const addSlider = (text, min, max, val, onChange) => {
-    const opacityWrapper = document.createElement('div');
-    opacityWrapper.classList.add(
-      'ao-opacity-wrapper',
-      'outlined',
-      'dropshadow',
-    );
+		const opacityWrapper = document.createElement('div');
+		opacityWrapper.classList.add('ao-opacity-wrapper', 'outlined', 'dropshadow');
 		opacityWrapper.title = text;
 
 		const opacitySlider = document.createElement('input');

--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -135,6 +135,7 @@ addEventListener('load', () => {
 	const canvasContainer = mainContainer.querySelector('#canvas-container');
 	const cursorCanvas = mainContainer.querySelector('#cursor-canvas');
 	const canvas = canvasContainer.querySelector('#chocolate-canvas');
+	const uiLayer = mainContainer.querySelector('#ui-layer');
 
 	// ==============================================
 	// Overlay image
@@ -209,7 +210,7 @@ addEventListener('load', () => {
 	const buttonsWrapper = document.createElement('div');
 	buttonsWrapper.classList.add('ao-wrapper');
 
-	mainContainer.appendChild(buttonsWrapper);
+	uiLayer.appendChild(buttonsWrapper);
 
 	const saveState = () => {
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(oState));

--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -26,6 +26,11 @@ const AO_STYLE = `
     gap: 12px;
     align-items: flex-end;
   }
+  @media (max-width : 600px) {
+    .ao-wrapper {
+      bottom: 85px;
+    }
+  }
   .ao-button {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
### Changes

- fix(advanced): avoid overlapping buttons in mobile view by adjusting wrapper y-position on small screens
- refactor(advanced): move buttons wrapper into ui layer, no visual change
- fix(advanced): restore outline and shadow of custom buttons by reuseing original css classes `outlined` and `dropshadow` instead of custom css
  - for me (Firefox) the outline and shadow for the custom ui buttons were not displayed as the css variables `--pixel-border` and `--pixel-box-shadow` do not exist or were not found:

**before:**  
<img width="72" height="278" alt="image" src="https://github.com/user-attachments/assets/406edd51-2e12-4370-902b-5ff4ab08a109" />

**after:**  
<img width="72" height="278" alt="image" src="https://github.com/user-attachments/assets/9d079573-a376-49ea-8099-afd6cde20b7d" />
