### PR TITLE
feat(advanced): add ">" or "<" to percentage stats when rounded to 0% or 100.0%

### DIFF
--- a/src/scripts/advanced_overlay.user.js
+++ b/src/scripts/advanced_overlay.user.js
@@ -341,6 +341,23 @@ addEventListener('load', () => {
 	monitorList.classList.add('ao-monitor-list');
 	monitorPanel.appendChild(monitorList);
 
+	const getFormattedCompletionText = (artwork, outputEta=false) => {
+		let text = artwork.completion.toFixed(1) + '%';
+		// prepend ">" or "<", if rounded to 0.0% or 100.0%
+		if (text === '0.0%' && artwork.completion > 0) {
+			text = '> 0.0%';
+		} else if (text === '100.0%' && artwork.completion < 100) {
+			text = '< 100.0%';
+		}
+		// append ETA, if present and requested
+		if (outputEta && artwork.eta_seconds != null && artwork.eta_seconds > 0) {
+			const mins = Math.floor(artwork.eta_seconds / 60);
+			const secs = Math.floor(artwork.eta_seconds % 60);
+			text += mins > 0 ? ` (${mins}m${secs}s)` : ` (${secs}s)`;
+		}
+		return text;
+	}
+
 	const updateMonitorPanel = () => {
 		const sorted = [...monitorArtworks.values()].sort((a, b) => a.completion - b.completion);
 		monitorList.innerHTML = '';
@@ -360,12 +377,7 @@ addEventListener('load', () => {
 			name.textContent = art.name;
 			name.title = art.name;
 
-			let pctText = art.completion.toFixed(1) + '%';
-			if (art.eta_seconds != null && art.eta_seconds > 0) {
-				const mins = Math.floor(art.eta_seconds / 60);
-				const secs = Math.floor(art.eta_seconds % 60);
-				pctText += mins > 0 ? ` (${mins}m${secs}s)` : ` (${secs}s)`;
-			}
+			const pctText = getFormattedCompletionText(art, outputEta=true);
 
 			const pct = document.createElement('span');
 			pct.classList.add('ao-monitor-pct');
@@ -460,7 +472,7 @@ addEventListener('load', () => {
 
 			ctx.font = '3px monospace';
 
-			const pctLabel = pct.toFixed(1) + '%';
+			let pctLabel = getFormattedCompletionText(art);
 			const pctMetrics = ctx.measureText(pctLabel);
 			const pctH = 4;
 			const pctW = pctMetrics.width + 2;


### PR DESCRIPTION
In the advanced view, the monitor overview can show 100.0% completion for a large artwork while some pixel are still missing. This is due to the rounding to the first decimal place.

This PR introduces "> 0.0%" and "< 100.0%" when the original value is not exactly 0 or 100. This is applied to both the list in the top right corner as well as the hover overlay text at each artwork.

### Changes
- add and use `getFormattedCompletionText(artwork, outputEta=false)` to generate the percentage texts
- add logic to prepend ">" and "<" to the existing text

In this example there is one wrong pixel in the left eye (from the viewers perspective):

<img width="305" height="329" src="https://github.com/user-attachments/assets/90beadae-4608-459c-ad0e-82ea72802bef" />
<img width="233" height="299" src="https://github.com/user-attachments/assets/3de9d705-ac21-4709-94b4-11e88de751b2" />
